### PR TITLE
Mod Manager now only reads zip files in directory

### DIFF
--- a/inc/modManagement.js
+++ b/inc/modManagement.js
@@ -82,7 +82,9 @@ ModManager.prototype.loadInstalledMods = function() {
     let JSZip = require('jszip');
 
     let modZipNames = file.readdirSync(this.modDirectoryPath, 'utf8');
-    modZipNames.splice(modZipNames.indexOf('mod-list.json'), 1);
+    modZipNames = modZipNames.filter(function(elem) {
+        return elem.slice(-4) === ".zip";
+    });
 
     this.installedMods = [];
     let mods = this.installedMods;


### PR DESCRIPTION
One of the mods had been duplicated in the list, that's because it
generated a file "__rzi_" type file that was able to be read like a zip.

This fixes #52 and also addresses one mark in #17