### PR TITLE
Better status showing

### DIFF
--- a/inc/modManagement.js
+++ b/inc/modManagement.js
@@ -58,7 +58,8 @@ ModManager.prototype.sendOnlineModInfo = function(window, modName) {
 };
 
 ModManager.prototype.sendModLoadStatus = function(window) {
-    window.webContents.send('modsLoadedStatus', this.modsLoaded);
+    if(this.onlineMods === null) window.webContents.send('modsLoadedStatus', null);
+    else window.webContents.send('modsLoadedStatus', this.modsLoaded);
 }
 
 ModManager.prototype.sendFactorioVersion = function(window) {
@@ -190,7 +191,9 @@ ModManager.prototype.loadOnlineMods = function() {
                }
            }
            else {
-               throw error;
+               if(error) helpers.log(`Error when fetching online mods. Error: ${error.message}`);
+               if(response) helpers.log(`Error when fetching online mods. Response code: ${response.statusCode}`);
+               mods = null;
            }
 
        });

--- a/view/inc.js
+++ b/view/inc.js
@@ -53,7 +53,16 @@ function showLoadingStatus(loaded, page, pageCount) {
         $('#modsLoadedStatus').html('<span class="glyphicon glyphicon-ok"></span>  All Mods Fetched');
     }
     else {
-        $('#modsLoadedStatus').html(`<span class="glyphicon glyphicon-refresh"></span>  Fetching Mods - ${page}/${pageCount}`);
+        if(loaded === null) {
+            $('#modsLoadedStatus').html('<span class="glyphicon glyphicon-info-sign"></span>  Error Fetching Mods');
+        }
+        else if(page && pageCount) {
+            let percent = Math.floor(page / pageCount * 100);
+            $('#modsLoadedStatus').html(`<span class="glyphicon glyphicon-refresh"></span>  Fetching Mods - ${percent}%`);
+        }
+        else {
+            $('#modsLoadedStatus').html(`<span class="glyphicon glyphicon-refresh"></span>  Fetching Mods`);
+        }
     }
 }
 


### PR DESCRIPTION
Now logs errors instead of throwing them, and indicates an error when
mods couldn't be fetched.
Also adds a bit more to the status so it won't show undefined as the
current progress.

Closes #65 and #70 