### PR TITLE
Feature multiple online mod versions

### DIFF
--- a/app.js
+++ b/app.js
@@ -42,8 +42,8 @@ appMessager.on('requestInstalledMods', function() {
 appMessager.on('requestOnlineMods', function() {
     modManager.sendOnlineMods(mainWindow);
 });
-appMessager.on('areModsLoaded', function() {
-    modManager.sendModLoadStatus(mainWindow);
+appMessager.on('requestModFetchStatus', function() {
+    modManager.sendModFetchStatus(mainWindow);
 });
 appMessager.on('requestPlayerInfo', function() {
     modManager.sendPlayerInfo(mainWindow);
@@ -258,6 +258,6 @@ function init() {
 
     modManager.loadPlayerData();
     modManager.loadInstalledMods();
-    modManager.loadOnlineMods();
+    modManager.fetchOnlineMods();
 
 }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -8,13 +8,11 @@ module.exports = {
         let type = null;
         if(property2 != undefined) {
             if(typeof arr[0][property][property2] === 'number') type = 'number';
-            else if(moment(arr[0][property][property2], moment.ISO_8601, true).isValid()) type = 'time';
             else if(typeof arr[0][property][property2] === 'string') type = 'string';
 
         }
         else {
             if(typeof arr[0][property] === 'number') type = 'number';
-            else if(moment(arr[0][property], moment.ISO_8601, true).isValid()) type = 'time';
             else if(typeof arr[0][property] === 'string') type = 'string';
         }
 
@@ -25,11 +23,6 @@ module.exports = {
             case 'number':
                 arr.sort(numberSort);
                 break;
-            case 'time':
-                arr.sort(timeSort);
-                break;
-            default:
-                module.exports.log(`Error sorting, property type not handled -- Prop: '${property}', Type: ${typeof arr[0][property]}`);
         }
 
         function stringSort(a, b) {
@@ -61,21 +54,20 @@ module.exports = {
             else if (a > b) return -1;
             else return 0;
         };
-        function timeSort(a, b) {
-            if(property2 != undefined) {
-                a = a[property][property2]
-                b = b[property][property2]
-            }
-            else {
-                a = a[property]
-                b = b[property]
-            }
+
+        return arr;
+    },
+
+    // Trying to make sortArrayByProp generic was proving to be a hindrance
+    // Made this to make sorting by update easier now that we have such a large data object for onlineMods
+    sortModsByRecentUpdate: function(mods) {
+        return mods.sort(function(a, b) {
+            a = a.releases[0].released_at;
+            b = b.releases[0].released_at;
 
             if (moment(a).isBefore(b)) return 1;
             else if (moment(a).isAfter(b)) return -1;
             else return 0;
-        };
-
-        return arr;
+        });
     }
 };

--- a/lib/modManagement.js
+++ b/lib/modManagement.js
@@ -244,9 +244,11 @@ ModManager.prototype.initiateDownload = function(window, modID, downloadLink) {
                 fs.unlinkSync(`${this.modDirectoryPath}/${name}_${version}.zip`);
                 logger.log(1, 'Deleted mod at: ' + `${this.modDirectoryPath}/${name}_v${version}.zip`);
 
-                this.loadInstalledMods(() => {
+                this.loadInstalledMods();
+                this.customEvents.once('installedModsLoaded', () => {
                     profileManager.updateProfilesWithNewMods(this.getInstalledModNames());
                 });
+
             });
             break;
         }
@@ -288,7 +290,8 @@ ModManager.prototype.manageDownload = function(item, webContents, profileManager
            logger.log(1, 'Downloaded mod successfully');
            webContents.send('dataModDownloadStatus', "finished");
            if(!this.customEvents.emit('modDownloaded', profileManager)) {
-               this.loadInstalledMods(() => {
+               this.loadInstalledMods();
+               this.customEvents.once('installedModsLoaded', () => {
                    profileManager.updateProfilesWithNewMods(this.getInstalledModNames());
                });
            }

--- a/lib/modManagement.js
+++ b/lib/modManagement.js
@@ -19,10 +19,13 @@ function ModManager(modListPath, modDirectoryPath, gamePath, playerDataPath, cus
     this.playerDataPath = playerDataPath;
     this.factorioVersion = '';
     this.installedMods = [];
-    this.onlineMods = [];
 
     this.customEvents = customEvents;
-    this.modsLoaded = false;
+
+    this.onlineMods = [];
+    this.onlineModsFetched = false;
+    this.onlineModTotalCount = 0; // Total number of mods in the mod portal
+    this.onlineModFetchedCount = 0; // The number of mods fetched so far, used for progress indicator
 
     this.playerUsername = '';
     this.playerToken = '';
@@ -62,9 +65,8 @@ ModManager.prototype.sendOnlineModInfo = function(window, modName) {
     }
 };
 
-ModManager.prototype.sendModLoadStatus = function(window) {
-    if(this.onlineMods === null) window.webContents.send('modsLoadedStatus', null);
-    else window.webContents.send('modsLoadedStatus', this.modsLoaded);
+ModManager.prototype.sendModFetchStatus = function(window) {
+    window.webContents.send('dataModFetchStatus', this.onlineModsFetched, this.onlineModFetchedCount, this.onlineModTotalCount);
 }
 
 ModManager.prototype.sendFactorioVersion = function(window) {
@@ -154,47 +156,63 @@ ModManager.prototype.loadPlayerData = function() {
 // Online Mod Management
 
 // window is an optional argument, if given will send data once loaded
-ModManager.prototype.loadOnlineMods = function() {
-    let mods = this.onlineMods;
-    let events = this.customEvents;
+ModManager.prototype.fetchOnlineMods = function() {
+    logger.log(1, 'Beginning to fetch online mods.');
+    let self = this; // Required to get class variables working properly in nested functions
+    self.onlineMods = [];
+    self.onlineModsFetched = false;
+    self.onlineModTotalCount = 0;
+    self.onlineModFetchedCount = 0;
 
     let apiURL = 'https://mods.factorio.com/api/mods';
     let options = '?page_size=20';
 
-
-    getOnlineModData(`${apiURL}${options}`, () => {
-        this.modsLoaded = true;
-        events.emit('onlineModsLoaded', true);
+    fetchOnlineModInfo(`${apiURL}${options}`, (error) => {
+        if(error) {
+            self.onlineMods = [];
+            logger.log(3, 'Error when fetching mods from the online mod portal. Continuing without any related functionality.', error);
+        }
+        else {
+            self.onlineModsFetched = true;
+            logger.log(1, 'All online mods were successfully fetched.');
+        }
     });
 
-    function getOnlineModData(url, callback) {
-
-       request(url ,function(error, response, data) {
-           if(!error && response.statusCode == 200) {
+    function fetchOnlineModInfo(url, callback) {
+       request(url, (error, response, data) => {
+           if(!error && response.statusCode === 200) {
                data = JSON.parse(data);
-
-               let page = data.pagination.page;
-               let pageCount = data.pagination.page_count;
-               events.emit('onlineModsLoaded', false, page, pageCount);
+               self.onlineModTotalCount = data.pagination.count;
 
                for(let i = 0; i < data['results'].length; i++) {
-                   mods.push(data['results'][i]);
+                   fetchFullOnlineMod(`${apiURL}/${data.results[i].name}`, (error) => {
+                       if(error) return callback(error);
+                       if(self.onlineModFetchedCount >= self.onlineModTotalCount) return callback(null);
+                   });
                }
 
                if(data['pagination']['links']['next']) {
-                   getOnlineModData(data['pagination']['links']['next'], callback);
-               }
-               else {
-                   callback();
+                   fetchOnlineModInfo(data['pagination']['links']['next'], callback);
                }
            }
            else {
-               if(error) logger.log(3, `Error when fetching online mods. Error: ${error.message}`);
-               if(response) logger.log(3, `Error when fetching online mods. Response code: ${response.statusCode}`);
-               mods = null;
+               return callback(error);
            }
 
        });
+    }
+
+    function fetchFullOnlineMod(url, callback) {
+        request(url, (error, response, data) => {
+            if(!error && response.statusCode === 200) {
+                self.onlineMods.push(JSON.parse(data));
+                self.onlineModFetchedCount++;
+                return callback(null);
+            }
+            else {
+                return callback(error);
+            }
+        });
     }
 };
 

--- a/lib/modManagement.js
+++ b/lib/modManagement.js
@@ -216,7 +216,7 @@ ModManager.prototype.fetchOnlineMods = function() {
     }
 };
 
-ModManager.prototype.initiateDownload = function(window, modID, modName) {
+ModManager.prototype.initiateDownload = function(window, modID, downloadLink) {
     if(!this.playerUsername || !this.playerToken) {
         return;
     }
@@ -244,8 +244,7 @@ ModManager.prototype.initiateDownload = function(window, modID, modName) {
                 fs.unlinkSync(`${this.modDirectoryPath}/${name}_${version}.zip`);
                 logger.log(1, 'Deleted mod at: ' + `${this.modDirectoryPath}/${name}_v${version}.zip`);
 
-                this.loadInstalledMods();
-                this.customEvents.once('installedModsLoaded', () => {
+                this.loadInstalledMods(() => {
                     profileManager.updateProfilesWithNewMods(this.getInstalledModNames());
                 });
             });
@@ -253,14 +252,11 @@ ModManager.prototype.initiateDownload = function(window, modID, modName) {
         }
     }
 
-    window.webContents.send('ping', modToDownload);
-
-    logger.log(1, `Attempting to download mod: ${modToDownload['name']}`);
-    let downloadURL = `https://mods.factorio.com${modToDownload['latest_release']['download_url']}`;
-    downloadURL += `?username=${this.playerUsername}&token=${this.playerToken}`;
+    logger.log(1, `Attempting to download mod: ${modToDownload.name}`);
+    let downloadURL = `https://mods.factorio.com${downloadLink}?username=${this.playerUsername}&token=${this.playerToken}`;
     window.webContents.send('ping', downloadURL);
 
-    window.webContents.send('dataModDownloadStatus', "starting", modName);
+    window.webContents.send('dataModDownloadStatus', "starting", modToDownload.name);
     window.webContents.downloadURL(downloadURL);
 };
 
@@ -292,9 +288,7 @@ ModManager.prototype.manageDownload = function(item, webContents, profileManager
            logger.log(1, 'Downloaded mod successfully');
            webContents.send('dataModDownloadStatus', "finished");
            if(!this.customEvents.emit('modDownloaded', profileManager)) {
-               this.loadInstalledMods();
-
-               this.customEvents.once('installedModsLoaded', () => {
+               this.loadInstalledMods(() => {
                    profileManager.updateProfilesWithNewMods(this.getInstalledModNames());
                });
            }

--- a/view/js/inc.js
+++ b/view/js/inc.js
@@ -6,7 +6,12 @@ messager.on('ping', function(event, message) {
     console.log(message);
 });
 
-messager.on('modsLoadedStatus', function(event, loaded, page, pageCount) {
+messager.on('dataModFetchStatus', function(event, loaded, page, pageCount) {
+    if(!loaded) {
+        window.setTimeout(() => {
+            messager.send('requestModFetchStatus');
+        }, 1000);
+    }
     showLoadingStatus(loaded, page, pageCount);
 });
 messager.on('dataPlayerInfo', function(event, username) {
@@ -38,7 +43,7 @@ $('button#page-about').click(function() {
 //---------------------------------------------------------
 //---------------------------------------------------------
 $(document).ready(function() {
-    messager.send('areModsLoaded');
+    messager.send('requestModFetchStatus');
     messager.send('requestPlayerInfo');
     messager.send('requestFactorioVersion');
 

--- a/view/js/inc.js
+++ b/view/js/inc.js
@@ -12,6 +12,9 @@ messager.on('dataModFetchStatus', function(event, loaded, page, pageCount) {
             messager.send('requestModFetchStatus');
         }, 1000);
     }
+    else {
+        messager.send('requestOnlineMods');
+    }
     showLoadingStatus(loaded, page, pageCount);
 });
 messager.on('dataPlayerInfo', function(event, username) {

--- a/view/js/page_onlineMods.js
+++ b/view/js/page_onlineMods.js
@@ -96,14 +96,13 @@ function listOnlineMods() {
         table.append(`<tr><td class="modReleases">${dropdownMenu}</td><td class="modName" id="${mods[i]['id']}">${mods[i]['name']}</td></tr>`);
         if(isModDownloaded(mods[i]['name'])) {
             $('table#mods-list tbody td').last().addClass('downloaded');
-            // Temporary disable until we get it set up with new mod data structure
-            // if(hasUpdate(mods[i])) {
-            //     $('table#mods-list tbody td').last().addClass('hasUpdate');
-            //     $('table#mods-list tbody td').last().prepend('<span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span> ');
-            // }
-            // else {
-            //     $('table#mods-list tbody td').last().prepend('<span class="glyphicon glyphicon-ok" aria-hidden="true"></span> ');
-            // }
+            if(hasUpdate(mods[i])) {
+                $('table#mods-list tbody td').last().addClass('hasUpdate');
+                $('table#mods-list tbody td').last().prepend('<span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span> ');
+            }
+            else {
+                $('table#mods-list tbody td').last().prepend('<span class="glyphicon glyphicon-ok" aria-hidden="true"></span> ');
+            }
 
         }
 
@@ -139,15 +138,12 @@ function showOnlineModInfo() {
     if(!canDownloadMods) {
         tableBody.append(`<tr><th colspan="2">Cannot Download Mods</th></tr>`);
     }
-    else if($(this).hasClass('hasUpdate')) {
-        tableBody.append(`<tr><th id="${mod['id']}" class="center download-mod" colspan="2"><a href="#">Update Mod</a></th></tr>`);
-    }
-    else if($(this).hasClass('downloaded')) {
-        tableBody.append(`<tr><th colspan="2">Already Have Mod</th></tr>`);
+    else if(isModDownloaded(mod.name)) {
+        tableBody.append(`<tr><th colspan="2">Get updates from the 'Installed Mods' page</th></tr>`);
     }
     else {
         if(mod.releases[release].download_url) {
-            tableBody.append(`<tr><th id="${mod['id']}" class="center download-mod" colspan="2"><a href="#">Download Mod</a></th></tr>`);
+            tableBody.append(`<tr><th data-id="${mod.id}" data-url="${mod.releases[release].download_url}" class="center download-mod" colspan="2"><a href="#">Download Mod</a></th></tr>`);
         }
     }
 
@@ -216,7 +212,9 @@ function showOnlineModInfo() {
 }
 
 function requestDownload(event) {
-    messager.send('requestDownload', selectedMod.id, selectedMod.name);
+    let id = $(this).data('id');
+    let url = $(this).data('url');
+    messager.send('requestDownload', id, url);
 }
 
 function showFiltersTags() {
@@ -255,10 +253,14 @@ function hasUpdate(mod) {
     let length = installedMods.length;
     for(let i = 0; i < length; i++) {
         if(installedMods[i].name === mod.name) {
-            if(isVersionHigher(installedMods[i].version, mod.latest_release.version) &&
-                mod.latest_release.factorio_version === factorioVersion) {
-                return true;
+            for(let j = 0; j < mod.releases.length; j++) {
+                if(mod.releases[j].factorio_version === factorioVersion &&
+                isVersionHigher(installedMods[i].version, mod.releases[j].version) ) {
+                    return true;
+                }
+
             }
+            return false;
         }
     }
     return false;


### PR DESCRIPTION
Allows browsing all versions of a mod on the portal, and downloading any.

I set things to up to only allow the most recent compatible mod to be downloaded in the case of updating, until I get a more sophisticated way of handling the mods in the app.

Closes #39