### PR TITLE
Correct behavior of selecting mod release

### DIFF
--- a/src/components/OnlineMods/components/OnlineModDetailedView.jsx
+++ b/src/components/OnlineMods/components/OnlineModDetailedView.jsx
@@ -9,8 +9,11 @@ export const OnlineModDetailedView = React.createClass({
   },
 
   sendDownloadRequest () {
+    let releaseNum = this.props.selectedOnlineMod.get(1)
+    if (releaseNum > this.props.mod.get('releases').size) releaseNum = 0
+
     let name = this.props.mod.get('name')
-    let link = this.props.mod.getIn(['releases', this.props.selectedOnlineMod.get(1), 'download_url'])
+    let link = this.props.mod.getIn(['releases', releaseNum, 'download_url'])
     this.props.requestDownload(name, link)
   },
 
@@ -31,11 +34,13 @@ export const OnlineModDetailedView = React.createClass({
             </div>
             <div className='panel-body'>
               <strong>Version</strong>
-              <select className='selectedOnlineModVersionsList'>
+              <select
+                className='selectedOnlineModVersionsList'
+                onChange={e => { setSelectedOnlineMod(selectedOnlineMod.get(0), Number(e.target.value)) }} >
                 {mod.get('releases', List()).map((release, key) => (
                   <option
                     key={key}
-                    onClick={() => setSelectedOnlineMod(selectedOnlineMod.get(0), key)} >
+                    value={key} >
                     {release.get('version')}
                   </option>
                 ))}

--- a/src/onlineMods.js
+++ b/src/onlineMods.js
@@ -1,4 +1,4 @@
-import {Map, List, fromJS} from 'immutable'
+import {List, fromJS} from 'immutable'
 import moment from 'moment'
 
 export function setOnlineMods (state, onlineMods) {
@@ -9,9 +9,6 @@ export function setSelectedOnlineMod (state, index, releaseIndex) {
   const onlineModsLength = state.get('onlineMods', List()).size
   if (index >= onlineModsLength) {
     index = onlineModsLength - 1
-    releaseIndex = 0
-  }
-  if (releaseIndex >= state.get('onlineMods', List()).get('releases', Map()).size) {
     releaseIndex = 0
   }
 

--- a/test/view/onlineMods_specs.js
+++ b/test/view/onlineMods_specs.js
@@ -68,23 +68,6 @@ describe('client-side onlineMods', () => {
         selectedOnlineMod: [1, 0]
       }))
     })
-
-    it('sets release to 0 if out of range for that mod', () => {
-      const state = fromJS({
-        onlineMods: [
-          { name: 'Mod1', releases: [{ version: '1.0.0' }, { version: '1.1.0' }] },
-          { name: 'Mod2', releases: [{ version: '1.0.0' }] }
-        ]
-      })
-      const nextState = OnlineMods.setSelectedOnlineMod(state, 1, 1)
-      expect(nextState).to.equal(fromJS({
-        onlineMods: [
-          { name: 'Mod1', releases: [{ version: '1.0.0' }, { version: '1.1.0' }] },
-          { name: 'Mod2', releases: [{ version: '1.0.0' }] }
-        ],
-        selectedOnlineMod: [1, 0]
-      }))
-    })
   })
 
   describe('setOnlineModFilter()', () => {


### PR DESCRIPTION
The select menu now properly calls setSelectedOnlineMod.
Also changed behavior to not correct the release number, as it was not
working with the altered online mod list that OnlineMod component uses.

Closes #93