### PR TITLE
Use environment variable for app start

### DIFF
--- a/app.js
+++ b/app.js
@@ -291,7 +291,12 @@ function init () {
 
         profileManager.updateProfilesWithNewMods(modManager.getInstalledModNames())
         profileManager.removeDeletedMods(modManager.getInstalledModNames())
-        mainWindow.loadURL(`file://${__dirname}/view/index.html`)
+
+        if (process.env.NODE_ENV === 'production') {
+          mainWindow.loadURL(`file://${__dirname}/view/index.html`)
+        } else {
+          mainWindow.loadURL(`file://${__dirname}/view/index_dev.html`)
+        }
 
         modManager.addOnlineModInfoToInstalledMods(() => {
           modManager.addLatestAvailableUpdate(() => {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "An unofficial mod manager for Factorio",
   "main": "app.js",
   "scripts": {
-    "start": "electron .",
+    "start": "cross-env NODE_ENV=development electron .",
+    "start:prod": "cross-env NODE_ENV=production electron .",
     "standard": "standard",
     "standard:fix": "standard --fix",
     "test": "mocha --compilers js:babel-core/register --require ignore-styles --require ./test/test_helper.js \"test/**/*@(.js|.jsx)\" ",
@@ -65,8 +66,9 @@
     "webpack-dev-server": "^2.4.2"
   },
   "dependencies": {
-    "immutable": "^3.8.1",
+    "cross-env": "^5.0.0",
     "electron-json-storage": "^3.0.4",
+    "immutable": "^3.8.1",
     "jszip": "^3.1.1",
     "moment": "^2.18.1",
     "react": "^15.4.2",

--- a/view/index_dev.html
+++ b/view/index_dev.html
@@ -8,6 +8,7 @@
 </head>
 <body>
   <div id="app"></div>
-  <script src="bundle.js"></script>
+  <script src="http://localhost:8080/bundle.js"></script>
+  <script src="http://localhost:8080/webpack-dev-server.js"></script>
 </body>
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,7 +33,12 @@ module.exports = {
     hot: true
   },
   plugins: [
-    new webpack.HotModuleReplacementPlugin()
+    new webpack.HotModuleReplacementPlugin(),
+    new webpack.DefinePlugin({
+        'process.env': {
+          'NODE_ENV': JSON.stringify('production')
+        }
+      }),
   ],
   target: 'electron-renderer'
 }


### PR DESCRIPTION
Instead of manually changing the way the client-side JS is loaded (via
bundle or dev-server), now use an environment variable to determine that
through the app.