### PR TITLE
Fix path guessing on linux

### DIFF
--- a/src/main/data/path-guesses.js
+++ b/src/main/data/path-guesses.js
@@ -64,7 +64,7 @@ if (currentPlatform === 'linux') {
     join(homeDir, './factorio/mods'),
   ])
 
-  paths.pathDir.push(...[
+  paths.playerDataFile.push(...[
     join(homeDir, '.factorio/player-data.json'),
     join(homeDir, '.factorio/config/player-data.json'),
   ])


### PR DESCRIPTION
The app couldnt start on linux due to a typo.